### PR TITLE
Improve update product missing item message

### DIFF
--- a/BusinessLogicLayer/Services/ProductsService.cs
+++ b/BusinessLogicLayer/Services/ProductsService.cs
@@ -70,7 +70,7 @@ public class ProductsService : IProductsService
 
         if (existingProduct == null)
         {
-            throw new ArgumentNullException(nameof(productUpdateRequest));
+            throw new ArgumentException($"Product with ID {productUpdateRequest.ProductID} not found.");
         }
 
         ValidationResult validationResult = await _productUpdateRequestValidator.ValidateAsync(productUpdateRequest);

--- a/ProductsUnitTests/ProductsServiceTests.cs
+++ b/ProductsUnitTests/ProductsServiceTests.cs
@@ -242,8 +242,9 @@ public class ProductsServiceTests
         Func<Task> act = async () => await _productsService.UpdateProduct(productUpdateRequest);
 
         // Assert
+        string expectedMessage = $"Product with ID {productUpdateRequest.ProductID} not found.";
         await act.Should().ThrowAsync<ArgumentException>()
-            .WithMessage("Value cannot be null. (Parameter 'productUpdateRequest')");
+            .WithMessage(expectedMessage);
         _productsRepositoryMock.Verify(repo => repo.UpdateProduct(It.IsAny<Product>()), Times.Never);
     }
 


### PR DESCRIPTION
## Summary
- show a clearer message when attempting to update a product that doesn't exist
- adjust the corresponding unit test

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not installed)*